### PR TITLE
Convert PCF form to simple WPF MVVM window

### DIFF
--- a/revit-pcf-exporter-WPF/PcfExporterWindow.xaml
+++ b/revit-pcf-exporter-WPF/PcfExporterWindow.xaml
@@ -1,0 +1,50 @@
+<Window x:Class="PCF_Exporter.PcfExporterWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="PCF Exporter" Height="450" Width="650" WindowStartupLocation="CenterOwner">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Themes/Dark.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="Element setup:" Grid.Row="0" VerticalAlignment="Center"/>
+        <TextBox Text="{Binding ExcelPath}" Grid.Row="0" Margin="0,5,5,5" />
+        <Button Content="Browse" Command="{Binding SelectExcelPathCommand}" Grid.Row="0" Grid.Column="1" Margin="5"/>
+
+        <TextBlock Text="Pipeline setup:" Grid.Row="1" VerticalAlignment="Center"/>
+        <TextBox Text="{Binding LDTPath}" Grid.Row="1" Margin="0,5,5,5" />
+        <Button Content="Browse" Command="{Binding SelectLDTPathCommand}" Grid.Row="1" Grid.Column="1" Margin="5"/>
+
+        <TextBlock Text="Output directory:" Grid.Row="2" VerticalAlignment="Center"/>
+        <TextBox Text="{Binding OutputDirectory}" Grid.Row="2" Margin="0,5,5,5" />
+        <Button Content="Browse" Command="{Binding SelectOutputDirectoryCommand}" Grid.Row="2" Grid.Column="1" Margin="5"/>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.ColumnSpan="2" Margin="0,10">
+            <RadioButton Content="Overwrite" IsChecked="{Binding Overwrite}"/>
+            <RadioButton Content="Append" IsChecked="{Binding Append}" Margin="20,0,0,0"/>
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="4" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Import" Command="{Binding ImportParametersCommand}" Margin="0,0,5,0"/>
+            <Button Content="Delete" Command="{Binding DeleteParametersCommand}" Margin="0,0,5,0"/>
+            <Button Content="Populate Elements" Command="{Binding PopulateElementsCommand}" Margin="0,0,5,0"/>
+            <Button Content="Populate Pipelines" Command="{Binding PopulatePipelinesCommand}" Margin="0,0,5,0"/>
+            <Button Content="Export" Command="{Binding ExportCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/revit-pcf-exporter-WPF/PcfExporterWindow.xaml.cs
+++ b/revit-pcf-exporter-WPF/PcfExporterWindow.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows;
+
+namespace PCF_Exporter
+{
+    public partial class PcfExporterWindow : Window
+    {
+        public PcfExporterWindow(PcfExporterViewModel vm)
+        {
+            InitializeComponent();
+            DataContext = vm;
+        }
+    }
+}

--- a/revit-pcf-exporter-WPF/Themes/Dark.xaml
+++ b/revit-pcf-exporter-WPF/Themes/Dark.xaml
@@ -1,0 +1,15 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="BackgroundColor">#FF3C3F41</Color>
+    <Color x:Key="ForegroundColor">#FFECECEC</Color>
+    <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}"/>
+    <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}"/>
+
+    <Style TargetType="{x:Type Window}">
+        <Setter Property="Background" Value="{StaticResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+    </Style>
+    <Style TargetType="{x:Type Control}">
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+    </Style>
+</ResourceDictionary>

--- a/revit-pcf-exporter-WPF/ViewModels/PcfExporterViewModel.cs
+++ b/revit-pcf-exporter-WPF/ViewModels/PcfExporterViewModel.cs
@@ -1,0 +1,179 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.WindowsAPICodePack.Dialogs;
+using PCF_Functions;
+using PCF_Parameters;
+using System.Data;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using mySettings = PCF_Exporter.Properties.Settings;
+using iv = PCF_Functions.InputVars;
+using dh = Shared.DataHandler;
+
+namespace PCF_Exporter.ViewModels
+{
+    public partial class PcfExporterViewModel : ObservableObject
+    {
+        private readonly UIApplication _uiapp;
+        private readonly UIDocument _uidoc;
+        private readonly Document _doc;
+        private readonly string _message;
+
+        private DataTable? _elementsTable;
+        private DataTable? _pipelinesTable;
+
+        public PcfExporterViewModel(ExternalCommandData cData, string message)
+        {
+            _uiapp = cData.Application;
+            _uidoc = _uiapp.ActiveUIDocument;
+            _doc = _uidoc.Document;
+            _message = message;
+
+            ExcelPath = mySettings.Default.excelPath;
+            if (File.Exists(ExcelPath))
+            {
+                var ds = dh.ReadExcelToDataSet(ExcelPath);
+                _elementsTable = dh.ReadDataTable(ds, "Elements");
+            }
+
+            LDTPath = mySettings.Default.LDTPath;
+            if (File.Exists(LDTPath))
+            {
+                var ds = dh.ReadExcelToDataSet(LDTPath);
+                _pipelinesTable = dh.ReadDataTable(ds, "Pipelines");
+            }
+
+            OutputDirectory = mySettings.Default.textBox5OutputPath;
+            Overwrite = mySettings.Default.radioButton15Overwrite;
+            Append = mySettings.Default.radioButton16Append;
+            iv.PCF_PROJECT_IDENTIFIER = mySettings.Default.TextBox11PROJECTIDENTIFIER;
+        }
+
+        [ObservableProperty]
+        private string _excelPath = string.Empty;
+
+        partial void OnExcelPathChanged(string value)
+        {
+            mySettings.Default.excelPath = value;
+        }
+
+        [ObservableProperty]
+        private string _ldtPath = string.Empty;
+
+        partial void OnLdtPathChanged(string value)
+        {
+            mySettings.Default.LDTPath = value;
+        }
+
+        [ObservableProperty]
+        private string _outputDirectory = string.Empty;
+
+        partial void OnOutputDirectoryChanged(string value)
+        {
+            iv.OutputDirectoryFilePath = value;
+            mySettings.Default.textBox5OutputPath = value;
+        }
+
+        [ObservableProperty]
+        private bool _overwrite = true;
+
+        partial void OnOverwriteChanged(bool value)
+        {
+            iv.Overwrite = value;
+            mySettings.Default.radioButton15Overwrite = value;
+            if (value) Append = false;
+        }
+
+        [ObservableProperty]
+        private bool _append;
+
+        partial void OnAppendChanged(bool value)
+        {
+            mySettings.Default.radioButton16Append = value;
+            if (value) Overwrite = false;
+        }
+
+        [RelayCommand]
+        private void SelectExcelPath()
+        {
+            var dialog = new CommonOpenFileDialog { Filters = { new CommonFileDialogFilter("Excel","*.xlsx;*.xls") } };
+            if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                ExcelPath = dialog.FileName;
+                var ds = dh.ReadExcelToDataSet(ExcelPath);
+                _elementsTable = dh.ReadDataTable(ds, "Elements");
+            }
+        }
+
+        [RelayCommand]
+        private void SelectLdtPath()
+        {
+            var dialog = new CommonOpenFileDialog { Filters = { new CommonFileDialogFilter("Excel","*.xlsx;*.xls") } };
+            if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                LDTPath = dialog.FileName;
+                var ds = dh.ReadExcelToDataSet(LDTPath);
+                _pipelinesTable = dh.ReadDataTable(ds, "Pipelines");
+            }
+        }
+
+        [RelayCommand]
+        private void SelectOutputDirectory()
+        {
+            var dialog = new CommonOpenFileDialog { IsFolderPicker = true };
+            if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                OutputDirectory = dialog.FileName;
+            }
+        }
+
+        [RelayCommand]
+        private void ImportParameters()
+        {
+            CreateParameterBindings cpb = new CreateParameterBindings();
+            cpb.CreateElementBindings(_uiapp, ref _message);
+            cpb.CreatePipelineBindings(_uiapp, ref _message);
+        }
+
+        [RelayCommand]
+        private void DeleteParameters()
+        {
+            DeleteParameters dp = new DeleteParameters();
+            dp.ExecuteMyCommand(_uiapp, ref _message);
+        }
+
+        [RelayCommand]
+        private void PopulateElements()
+        {
+            if (_elementsTable == null)
+            {
+                Debug.WriteLine("Elements table null");
+                return;
+            }
+            PopulateParameters pp = new PopulateParameters();
+            pp.PopulateElementData(_uiapp, ref _message, _elementsTable);
+        }
+
+        [RelayCommand]
+        private void PopulatePipelines()
+        {
+            if (_pipelinesTable == null)
+            {
+                Debug.WriteLine("Pipelines table null");
+                return;
+            }
+            PopulateParameters pp = new PopulateParameters();
+            pp.PopulatePipelineData(_uiapp, ref _message, _pipelinesTable);
+        }
+
+        [RelayCommand]
+        private void Export()
+        {
+            PCFExport exporter = new PCFExport();
+            exporter.ExecuteMyCommand(_uiapp, ref _message);
+        }
+    }
+}

--- a/revit-pcf-exporter-WPF/revit-pcf-exporter-WPF.csproj
+++ b/revit-pcf-exporter-WPF/revit-pcf-exporter-WPF.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,6 +62,8 @@
       <HintPath>..\packages\WindowsAPICodePack.7.0.4\lib\net48\Microsoft.WindowsAPICodePack.ShellExtensions.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="CommunityToolkit.Mvvm" />
     <Reference Include="RevitAPI">
       <HintPath>..\..\..\..\Revit API\2024\RevitAPI.dll</HintPath>
       <Private>False</Private>
@@ -137,6 +140,10 @@
     <Compile Include="Dark_PCF_Exporter_form.Designer.cs">
       <DependentUpon>Dark_PCF_Exporter_form.cs</DependentUpon>
     </Compile>
+    <Compile Include="PcfExporterWindow.xaml.cs">
+      <DependentUpon>PcfExporterWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ViewModels\PcfExporterViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -148,6 +155,8 @@
     <EmbeddedResource Include="Dark_PCF_Exporter_form.resx">
       <DependentUpon>Dark_PCF_Exporter_form.cs</DependentUpon>
     </EmbeddedResource>
+    <Page Include="PcfExporterWindow.xaml" />
+    <Page Include="Themes\Dark.xaml" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Properties\Settings.settings">

--- a/revit-pcf-exporter-shared/App.cs
+++ b/revit-pcf-exporter-shared/App.cs
@@ -12,6 +12,7 @@ using PCF_Functions;
 //using mySettings = PCF_Functions.Properties.Settings;
 using PCF_Taps;
 using System.Diagnostics;
+using PCF_Exporter.ViewModels;
 
 namespace PCF_Exporter
 {
@@ -87,10 +88,10 @@ namespace PCF_Exporter
             try
             {
                 DocumentManager.Instance.Initialize(commandData.Application.ActiveUIDocument.Document);
-                Dark_PCF_Exporter_form fm = new Dark_PCF_Exporter_form(commandData, message);
-                fm.ShowDialog();
+                var vm = new ViewModels.PcfExporterViewModel(commandData, message);
+                var win = new PcfExporterWindow(vm);
+                win.ShowDialog();
                 PCF_Exporter.Properties.Settings.Default.Save();
-                fm.Close();
                 return Result.Succeeded;
             }
 


### PR DESCRIPTION
## Summary
- add new dark themed WPF window `PcfExporterWindow`
- implement `PcfExporterViewModel` using CommunityToolkit.Mvvm
- provide shared dark styles
- open the new window from `FormCaller`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*